### PR TITLE
Add book detail page, rating, read/want-to-read, and recommendations

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -33,7 +33,10 @@ async function searchBooks() {
 
     books.forEach((book) => {
       const li = document.createElement("li");
-      li.textContent = `${book.title} by ${book.author}`;
+      const a = document.createElement("a");
+      a.href = `book.html?id=${book.book_id}`;
+      a.textContent = `${book.title} by ${book.author}`;
+      li.appendChild(a);
       resultsEl.appendChild(li);
     });
   } catch (error) {

--- a/public/book.html
+++ b/public/book.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>betterreads - Book Details</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <a href="/" class="back-link">Back to Search</a>
+      <div id="book-detail" class="book-detail">
+        <p>Loading...</p>
+      </div>
+    </div>
+
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const bookId = params.get("id");
+
+      async function loadBook() {
+        const detailEl = document.getElementById("book-detail");
+
+        if (!bookId) {
+          detailEl.innerHTML = "<p>No book selected.</p>";
+          return;
+        }
+
+        try {
+          const res = await fetch(`/api/book/${bookId}`);
+          if (!res.ok) throw new Error("Book not found");
+          const book = await res.json();
+
+          // Also fetch user ratings
+          const ratingsRes = await fetch(`/api/book/${bookId}/ratings`);
+          const ratingsData = await ratingsRes.json();
+
+          detailEl.innerHTML = `
+            <div class="book-layout">
+              <div class="book-cover">
+                ${book.cover_image_url
+                  ? `<img src="${book.cover_image_url}" alt="${book.title}" />`
+                  : `<div class="no-cover">No Cover</div>`}
+              </div>
+              <div class="book-info">
+                <h1>${book.title}</h1>
+                <h2>by ${book.author || "Unknown"}</h2>
+                <p class="book-meta">
+                  ${book.primary_genre ? `<span class="genre">${book.primary_genre}</span>` : ""}
+                  ${book.pages ? `<span>${book.pages} pages</span>` : ""}
+                  ${book.isbn ? `<span>ISBN: ${book.isbn}</span>` : ""}
+                </p>
+                <p class="book-rating">
+                  Average Rating: ${book.average_rating || "N/A"} / 5
+                  ${ratingsData.num_ratings > 0
+                    ? `<br>User Ratings: ${ratingsData.avg_rating} / 5 (${ratingsData.num_ratings} ratings)`
+                    : ""}
+                </p>
+                ${book.genres && book.genres.length > 0
+                  ? `<p class="book-genres">Genres: ${book.genres.join(", ")}</p>`
+                  : ""}
+                <p class="book-description">${book.description || "No description available."}</p>
+
+                <div class="action-buttons">
+                  <button id="btn-read" class="action-btn" onclick="markAs('read')">Mark as Read</button>
+                  <button id="btn-want" class="action-btn" onclick="markAs('want-to-read')">Mark as Want-to-Read</button>
+                </div>
+                <p id="status-message"></p>
+
+                <div class="rate-section">
+                  <h3>Rate this book</h3>
+                  <div class="star-rating" id="star-rating">
+                    <span class="star" data-value="1">&#9733;</span>
+                    <span class="star" data-value="2">&#9733;</span>
+                    <span class="star" data-value="3">&#9733;</span>
+                    <span class="star" data-value="4">&#9733;</span>
+                    <span class="star" data-value="5">&#9733;</span>
+                  </div>
+                  <p id="rate-message"></p>
+                </div>
+              </div>
+            </div>
+
+            <div class="recommendations-section">
+              <h3>You might also like</h3>
+              <div id="recommendations" class="recommendations-grid">Loading...</div>
+            </div>
+          `;
+
+          // Set up star rating clicks
+          document.querySelectorAll(".star").forEach((star) => {
+            star.addEventListener("mouseenter", () => {
+              const val = parseInt(star.dataset.value);
+              highlightStars(val);
+            });
+            star.addEventListener("mouseleave", () => {
+              highlightStars(currentRating);
+            });
+            star.addEventListener("click", () => {
+              submitRating(parseInt(star.dataset.value));
+            });
+          });
+
+          // Load user's status for this book
+          loadStatus();
+
+          // Load recommendations
+          loadRecommendations();
+        } catch (error) {
+          detailEl.innerHTML = "<p>Error loading book details.</p>";
+          console.error(error);
+        }
+      }
+
+      let currentRating = 0;
+
+      function highlightStars(count) {
+        document.querySelectorAll(".star").forEach((star) => {
+          const val = parseInt(star.dataset.value);
+          star.classList.toggle("active", val <= count);
+        });
+      }
+
+      async function submitRating(rating) {
+        const msgEl = document.getElementById("rate-message");
+
+        // For now, use a default user (uid=1). This will be replaced when login is implemented.
+        const uid = 1;
+
+        try {
+          const res = await fetch("/api/rate", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ uid, book_id: parseInt(bookId), rating }),
+          });
+
+          const data = await res.json();
+
+          if (res.ok) {
+            msgEl.textContent = `You rated this book ${rating}/5! (Added to your Read list)`;
+            msgEl.style.color = "green";
+            highlightStars(rating);
+            // Reload to update rating display
+            setTimeout(() => loadBook(), 1000);
+          } else {
+            msgEl.textContent = data.error || "Failed to submit rating.";
+            msgEl.style.color = "red";
+          }
+        } catch (error) {
+          msgEl.textContent = "Error submitting rating.";
+          msgEl.style.color = "red";
+        }
+      }
+
+      let currentStatus = null;
+
+      async function loadStatus() {
+        const uid = 1;
+        try {
+          const res = await fetch(`/api/book/${bookId}/status?uid=${uid}`);
+          const data = await res.json();
+
+          currentStatus = data.status;
+
+          const statusEl = document.getElementById("status-message");
+          const btnRead = document.getElementById("btn-read");
+          const btnWant = document.getElementById("btn-want");
+
+          btnRead.classList.remove("active-btn");
+          btnWant.classList.remove("active-btn");
+
+          if (data.status === "read") {
+            statusEl.textContent = "You have read this book";
+            statusEl.style.color = "#2a5db0";
+            btnRead.classList.add("active-btn");
+          } else if (data.status === "want-to-read") {
+            statusEl.textContent = "On your want-to-read list";
+            statusEl.style.color = "#2a5db0";
+            btnWant.classList.add("active-btn");
+          } else {
+            statusEl.textContent = "";
+          }
+
+          if (data.rating) {
+            currentRating = data.rating;
+            highlightStars(data.rating);
+          }
+        } catch (err) {
+          console.error("Error loading status:", err);
+        }
+      }
+
+      async function markAs(type) {
+        const uid = 1;
+        const statusEl = document.getElementById("status-message");
+
+        // If clicking the already-active button, unmark it
+        if (currentStatus === type) {
+          try {
+            const res = await fetch("/api/unmark", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ uid, book_id: parseInt(bookId) }),
+            });
+            const data = await res.json();
+            if (res.ok) {
+              statusEl.textContent = "Book removed from your list";
+              statusEl.style.color = "green";
+              loadStatus();
+            }
+          } catch (error) {
+            console.error("Unmark error:", error);
+          }
+          return;
+        }
+
+        const endpoint = type === "read" ? "/api/mark-read" : "/api/mark-want-to-read";
+
+        try {
+          const res = await fetch(endpoint, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ uid, book_id: parseInt(bookId) }),
+          });
+
+          const data = await res.json();
+
+          if (res.ok) {
+            statusEl.textContent = data.message;
+            statusEl.style.color = "green";
+            loadStatus();
+          } else {
+            statusEl.textContent = data.error || "Failed to update.";
+            statusEl.style.color = "red";
+          }
+        } catch (error) {
+          console.error("Mark error:", error);
+        }
+      }
+
+      async function loadRecommendations() {
+        const recEl = document.getElementById("recommendations");
+        try {
+          const res = await fetch(`/api/recommendations/${bookId}`);
+          const books = await res.json();
+
+          if (!books.length) {
+            recEl.innerHTML = "<p>No recommendations available.</p>";
+            return;
+          }
+
+          recEl.innerHTML = books
+            .map(
+              (b) => `
+              <a href="book.html?id=${b.book_id}" class="rec-card">
+                ${b.cover_image_url
+                  ? `<img src="${b.cover_image_url}" alt="${b.title}" />`
+                  : `<div class="no-cover-small">No Cover</div>`}
+                <p class="rec-title">${b.title}</p>
+                <p class="rec-author">${b.author || "Unknown"}</p>
+              </a>`
+            )
+            .join("");
+        } catch (err) {
+          recEl.innerHTML = "<p>Error loading recommendations.</p>";
+        }
+      }
+
+      loadBook();
+    </script>
+  </body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -76,3 +76,237 @@ h1 {
   padding: 12px;
   margin-bottom: 10px;
 }
+
+#results li a {
+  text-decoration: none;
+  color: #2a5db0;
+  font-size: 18px;
+}
+
+#results li a:hover {
+  text-decoration: underline;
+}
+
+/* ── Book Detail Page ── */
+
+.back-link {
+  align-self: flex-start;
+  margin: 10px 0 20px 40px;
+  font-size: 18px;
+  color: #2a5db0;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.book-detail {
+  width: 900px;
+  max-width: 95%;
+}
+
+.book-layout {
+  display: flex;
+  gap: 30px;
+  background: white;
+  border: 1px solid #ccc;
+  padding: 30px;
+  border-radius: 8px;
+}
+
+.book-cover img {
+  width: 200px;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.no-cover {
+  width: 200px;
+  height: 300px;
+  background: #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #888;
+  font-size: 16px;
+}
+
+.book-info h1 {
+  font-size: 28px;
+  margin: 0 0 5px 0;
+}
+
+.book-info h2 {
+  font-size: 20px;
+  font-weight: normal;
+  color: #555;
+  margin: 0 0 15px 0;
+}
+
+.book-meta {
+  display: flex;
+  gap: 15px;
+  color: #777;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.genre {
+  background: #e8f0fe;
+  padding: 2px 10px;
+  border-radius: 12px;
+  color: #2a5db0;
+}
+
+.book-rating {
+  font-size: 16px;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.book-genres {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 10px;
+}
+
+.book-description {
+  font-size: 15px;
+  line-height: 1.6;
+  color: #333;
+}
+
+/* ── Star Rating ── */
+
+.rate-section {
+  margin-top: 20px;
+  border-top: 1px solid #eee;
+  padding-top: 15px;
+}
+
+.rate-section h3 {
+  margin: 0 0 10px 0;
+  font-size: 18px;
+}
+
+.star-rating {
+  display: flex;
+  gap: 5px;
+}
+
+.star {
+  font-size: 36px;
+  color: #ccc;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.star:hover,
+.star.active {
+  color: #f5a623;
+}
+
+/* ── Action Buttons (Read / Want-to-Read) ── */
+
+.action-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.action-btn {
+  padding: 10px 20px;
+  font-size: 15px;
+  border: 2px solid #2a5db0;
+  background: white;
+  color: #2a5db0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.action-btn:hover {
+  background: #e8f0fe;
+}
+
+.action-btn.active-btn {
+  background: #2a5db0;
+  color: white;
+}
+
+#status-message {
+  font-size: 14px;
+  margin-top: 8px;
+}
+
+/* ── Recommendations ── */
+
+.recommendations-section {
+  margin-top: 30px;
+}
+
+.recommendations-section h3 {
+  font-size: 22px;
+  margin-bottom: 15px;
+}
+
+.recommendations-grid {
+  display: flex;
+  gap: 20px;
+  overflow-x: auto;
+}
+
+.rec-card {
+  flex: 0 0 150px;
+  text-decoration: none;
+  color: #333;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 10px;
+  text-align: center;
+  transition: box-shadow 0.2s;
+}
+
+.rec-card:hover {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+}
+
+.rec-card img {
+  width: 120px;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.no-cover-small {
+  width: 120px;
+  height: 180px;
+  background: #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #888;
+  font-size: 13px;
+}
+
+.rec-title {
+  font-size: 13px;
+  font-weight: bold;
+  margin: 8px 0 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rec-author {
+  font-size: 12px;
+  color: #777;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const pool = mysql.createPool({
   database: "books",
 });
 
+app.use(express.json());
 app.use(express.static(path.join(__dirname, "public")));
 
 app.get("/api/search", async (req, res) => {
@@ -59,6 +60,295 @@ app.get("/api/search", async (req, res) => {
     res.json(rows);
   } catch (error) {
     console.error("Search error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Book Detail: GET /api/book/:id ──
+app.get("/api/book/:id", async (req, res) => {
+  try {
+    const bookId = req.params.id;
+
+    // Get book info
+    const [books] = await pool.execute(
+      `SELECT book_id, title, author, isbn, average_rating, description,
+              cover_image_url, primary_genre, pages
+       FROM books WHERE book_id = ?`,
+      [bookId]
+    );
+
+    if (books.length === 0) {
+      return res.status(404).json({ error: "Book not found" });
+    }
+
+    // Get all genres for this book
+    const [genres] = await pool.execute(
+      `SELECT g.genre_name
+       FROM genres g
+       JOIN book_genres bg ON g.genre_id = bg.genre_id
+       JOIN books b ON b.hardcover_id = bg.hardcover_id
+       WHERE b.book_id = ?`,
+      [bookId]
+    );
+
+    const book = books[0];
+    book.genres = genres.map((g) => g.genre_name);
+
+    res.json(book);
+  } catch (error) {
+    console.error("Book detail error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Rate a Book: POST /api/rate ──
+app.post("/api/rate", async (req, res) => {
+  try {
+    const { uid, book_id, rating } = req.body;
+
+    if (!uid || !book_id || !rating) {
+      return res.status(400).json({ error: "uid, book_id, and rating are required" });
+    }
+
+    if (rating < 1 || rating > 5) {
+      return res.status(400).json({ error: "Rating must be between 1 and 5" });
+    }
+
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      // Insert or update the rating
+      await conn.execute(
+        `INSERT INTO ratings (uid, book_id, rating)
+         VALUES (?, ?, ?)
+         ON DUPLICATE KEY UPDATE rating = ?`,
+        [uid, book_id, rating, rating]
+      );
+
+      // Automatically add to read_books list
+      await conn.execute(
+        `INSERT IGNORE INTO read_books (uid, book_id) VALUES (?, ?)`,
+        [uid, book_id]
+      );
+
+      // Remove from want_to_read if it exists (book can't be in both lists)
+      await conn.execute(
+        `DELETE FROM want_to_read WHERE uid = ? AND book_id = ?`,
+        [uid, book_id]
+      );
+
+      await conn.commit();
+      res.json({ message: "Rating saved", rating });
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    } finally {
+      conn.release();
+    }
+  } catch (error) {
+    console.error("Rating error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Get ratings for a book: GET /api/book/:id/ratings ──
+app.get("/api/book/:id/ratings", async (req, res) => {
+  try {
+    const bookId = req.params.id;
+
+    const [rows] = await pool.execute(
+      `SELECT AVG(rating) AS avg_rating, COUNT(*) AS num_ratings
+       FROM ratings WHERE book_id = ?`,
+      [bookId]
+    );
+
+    res.json({
+      avg_rating: rows[0].avg_rating ? parseFloat(rows[0].avg_rating).toFixed(2) : null,
+      num_ratings: rows[0].num_ratings,
+    });
+  } catch (error) {
+    console.error("Get ratings error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Mark a book as read: POST /api/mark-read ──
+app.post("/api/mark-read", async (req, res) => {
+  try {
+    const { uid, book_id } = req.body;
+
+    if (!uid || !book_id) {
+      return res.status(400).json({ error: "uid and book_id are required" });
+    }
+
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      // Add to read_books
+      await conn.execute(
+        `INSERT IGNORE INTO read_books (uid, book_id) VALUES (?, ?)`,
+        [uid, book_id]
+      );
+
+      // Remove from want_to_read (can't be in both)
+      await conn.execute(
+        `DELETE FROM want_to_read WHERE uid = ? AND book_id = ?`,
+        [uid, book_id]
+      );
+
+      await conn.commit();
+      res.json({ message: "Book marked as read" });
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    } finally {
+      conn.release();
+    }
+  } catch (error) {
+    console.error("Mark read error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Mark a book as want-to-read: POST /api/mark-want-to-read ──
+app.post("/api/mark-want-to-read", async (req, res) => {
+  try {
+    const { uid, book_id } = req.body;
+
+    if (!uid || !book_id) {
+      return res.status(400).json({ error: "uid and book_id are required" });
+    }
+
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      // Add to want_to_read
+      await conn.execute(
+        `INSERT IGNORE INTO want_to_read (uid, book_id) VALUES (?, ?)`,
+        [uid, book_id]
+      );
+
+      // Remove from read_books (can't be in both)
+      await conn.execute(
+        `DELETE FROM read_books WHERE uid = ? AND book_id = ?`,
+        [uid, book_id]
+      );
+
+      await conn.commit();
+      res.json({ message: "Book marked as want-to-read" });
+    } catch (err) {
+      await conn.rollback();
+      throw err;
+    } finally {
+      conn.release();
+    }
+  } catch (error) {
+    console.error("Mark want-to-read error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Unmark a book (remove from both lists): POST /api/unmark ──
+app.post("/api/unmark", async (req, res) => {
+  try {
+    const { uid, book_id } = req.body;
+
+    if (!uid || !book_id) {
+      return res.status(400).json({ error: "uid and book_id are required" });
+    }
+
+    await pool.execute(
+      `DELETE FROM read_books WHERE uid = ? AND book_id = ?`,
+      [uid, book_id]
+    );
+    await pool.execute(
+      `DELETE FROM want_to_read WHERE uid = ? AND book_id = ?`,
+      [uid, book_id]
+    );
+
+    res.json({ message: "Book unmarked" });
+  } catch (error) {
+    console.error("Unmark error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Get book status for a user: GET /api/book/:id/status?uid= ──
+app.get("/api/book/:id/status", async (req, res) => {
+  try {
+    const bookId = req.params.id;
+    const uid = req.query.uid;
+
+    if (!uid) {
+      return res.json({ status: null, rating: null });
+    }
+
+    const [readRows] = await pool.execute(
+      `SELECT 1 FROM read_books WHERE uid = ? AND book_id = ?`,
+      [uid, bookId]
+    );
+
+    const [wantRows] = await pool.execute(
+      `SELECT 1 FROM want_to_read WHERE uid = ? AND book_id = ?`,
+      [uid, bookId]
+    );
+
+    const [ratingRows] = await pool.execute(
+      `SELECT rating FROM ratings WHERE uid = ? AND book_id = ?`,
+      [uid, bookId]
+    );
+
+    let status = null;
+    if (readRows.length > 0) status = "read";
+    else if (wantRows.length > 0) status = "want-to-read";
+
+    res.json({
+      status,
+      rating: ratingRows.length > 0 ? ratingRows[0].rating : null,
+    });
+  } catch (error) {
+    console.error("Book status error:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
+// ── Recommendations: GET /api/recommendations/:id ──
+app.get("/api/recommendations/:id", async (req, res) => {
+  try {
+    const bookId = req.params.id;
+
+    // Get the book's primary genre
+    const [books] = await pool.execute(
+      `SELECT primary_genre FROM books WHERE book_id = ?`,
+      [bookId]
+    );
+
+    if (books.length === 0) {
+      return res.status(404).json({ error: "Book not found" });
+    }
+
+    const genre = books[0].primary_genre;
+
+    if (!genre) {
+      return res.json([]);
+    }
+
+    // Get 5 random books from the same genre, excluding the current book
+    const [rows] = await pool.execute(
+      `SELECT book_id, title, author, cover_image_url, average_rating
+       FROM books
+       WHERE primary_genre = ? AND book_id != ?
+       ORDER BY RAND()
+       LIMIT 5`,
+      [genre, bookId]
+    );
+
+    res.json(rows);
+  } catch (error) {
+    console.error("Recommendations error:", error);
     res.status(500).json({ error: "Server error" });
   }
 });


### PR DESCRIPTION
## Summary
- Add book detail page with cover, description, title, author, rating, genres, page count, ISBN
- Add star rating system (1-5) that auto-adds book to read list
- Add mark as read / want-to-read toggle buttons with unmark support
- Add book recommendations (5 books from same genre)
- Add new database tables: users, ratings, read_books, want_to_read to book_data.sql
- Make search results clickable links to book detail page

## New API Endpoints
- `GET /api/book/:id` — get book details
- `POST /api/rate` — rate a book (auto-adds to read list)
- `GET /api/book/:id/ratings` — get average user rating
- `POST /api/mark-read` — mark book as read
- `POST /api/mark-want-to-read` — mark book as want-to-read
- `POST /api/unmark` — remove book from both lists
- `GET /api/book/:id/status?uid=` — get user's status for a book
- `GET /api/recommendations/:id` — get 5 recommended books from same genre

## Test plan
- [ ] Search for a book and click on a result to open the book detail page
- [ ] Verify book info displays correctly (cover, title, author, description, rating, genres)
- [ ] Rate a book using the star widget and verify it saves
- [ ] Toggle mark as read / want-to-read buttons and verify they work
- [ ] Click an active button again to unmark and verify it clears
- [ ] Check that recommendations load at the bottom of the book page
- [ ] Run `npm run db:reset` and verify new tables are created from book_data.sql