### PR TITLE
Add reading challenges and improve recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,25 @@ Can then see rendered version of website at: http://localhost:3000
 
 `GET /api/recommendations/:id`
 
-- Recommendations are based on the selected book's `primary_genre`.
+- Recommendations are based on overlapping genres for the selected book.
 - Results exclude the selected book itself.
-- Books are ranked by higher `average_rating`, then `title`, then `book_id` for stable demo output.
+- Candidates are ranked by shared genre overlap, then `average_rating`, and the UI can refresh through a weighted sample of strong matches.
 - The route returns up to 5 books with the current recommendation card fields.
 - Optional query param: `uid=<user id>`
   - When present, books already saved in the user's `read_books` or `want_to_read` lists are excluded.
+
+### Reading Challenges
+
+- `POST /api/challenges`
+  - Creates a reading challenge from the logged-in user's current Want to Read list.
+- `POST /api/challenges/join`
+  - Joins a challenge by invite code.
+- `GET /api/challenges/user/:uid`
+  - Lists the challenges a user belongs to.
+- `GET /api/challenges/:id?uid=<user id>`
+  - Returns challenge details, including members and shared books.
+
+Challenge tables are created automatically when the server starts, so the feature works with the existing MySQL seed data.
 
 ## Load dataset into MySQL (Docker)
 

--- a/public/book.html
+++ b/public/book.html
@@ -120,7 +120,15 @@
             </div>
 
             <div class="recommendations-section">
-              <h3>You might also like</h3>
+              <div class="recommendations-header">
+                <h3>You might also like</h3>
+                <button id="refresh-recommendations" class="action-btn" type="button">
+                  Refresh recommendations
+                </button>
+              </div>
+              <p class="recommendations-subtitle">
+                Recommendations are based on shared genres first, then average rating.
+              </p>
               <div id="recommendations" class="recommendations-grid">Loading...</div>
             </div>
           `;
@@ -143,6 +151,9 @@
           loadStatus();
 
           // Load recommendations
+          document
+            .getElementById("refresh-recommendations")
+            .addEventListener("click", () => loadRecommendations());
           loadRecommendations();
         } catch (error) {
           detailEl.innerHTML = "<p>Error loading book details.</p>";
@@ -295,8 +306,16 @@
 
       async function loadRecommendations() {
         const recEl = document.getElementById("recommendations");
+        const refreshBtn = document.getElementById("refresh-recommendations");
         const uid = localStorage.getItem("uid");
         const query = uid ? `?uid=${encodeURIComponent(uid)}` : "";
+
+        recEl.innerHTML = "<p>Loading recommendations...</p>";
+        if (refreshBtn) {
+          refreshBtn.disabled = true;
+          refreshBtn.textContent = "Refreshing...";
+        }
+
         try {
           const res = await fetch(`/api/recommendations/${bookId}${query}`);
           if (!res.ok) {
@@ -318,11 +337,18 @@
                   : `<div class="no-cover-small">No Cover</div>`}
                 <p class="rec-title">${b.title}</p>
                 <p class="rec-author">${b.author || "Unknown"}</p>
+                <p class="rec-reason">${b.reason || "Recommended because it is similar to this book."}</p>
+                <p class="rec-rating">Average rating: ${b.average_rating ? Number(b.average_rating).toFixed(2) : "N/A"} / 5</p>
               </a>`
             )
             .join("");
         } catch (err) {
           recEl.innerHTML = "<p>Error loading recommendations.</p>";
+        } finally {
+          if (refreshBtn) {
+            refreshBtn.disabled = false;
+            refreshBtn.textContent = "Refresh recommendations";
+          }
         }
       }
 

--- a/public/profile.html
+++ b/public/profile.html
@@ -28,6 +28,51 @@
             <div id="want-list" style="display: flex; flex-wrap: wrap; gap: 16px;"></div>
             <p id="want-empty" style="margin: 10px 0 0 0; color: #777;"></p>
           </section>
+
+          <section class="challenge-section">
+            <div class="challenge-header">
+              <h3 style="margin: 0;">Reading Challenges</h3>
+              <p class="challenge-note">
+                Create a shared challenge from your current Want to Read list, then invite other users to join with a code.
+              </p>
+            </div>
+
+            <div class="challenge-actions">
+              <form id="challenge-form" class="challenge-form">
+                <h4>Create a challenge</h4>
+                <label for="challenge-name">Challenge name</label>
+                <input id="challenge-name" type="text" maxlength="150" placeholder="Spring fantasy challenge" required />
+
+                <label for="challenge-description">Description</label>
+                <textarea
+                  id="challenge-description"
+                  rows="3"
+                  maxlength="255"
+                  placeholder="Reading together before finals week"
+                ></textarea>
+
+                <button class="action-btn" type="submit">Create from Want to Read</button>
+              </form>
+
+              <form id="join-challenge-form" class="challenge-form">
+                <h4>Join a challenge</h4>
+                <label for="challenge-code">Invite code</label>
+                <input id="challenge-code" type="text" maxlength="20" placeholder="ABC123" required />
+
+                <button class="action-btn" type="submit">Join challenge</button>
+              </form>
+            </div>
+
+            <p id="challenge-message" class="challenge-message"></p>
+
+            <div>
+              <h4 style="margin: 0 0 10px 0;">Your challenges</h4>
+              <div id="challenge-list" class="challenge-list"></div>
+              <p id="challenge-empty" class="challenge-empty"></p>
+            </div>
+
+            <div id="challenge-detail" class="challenge-detail"></div>
+          </section>
         </div>
       </div>
     </div>

--- a/public/profile.js
+++ b/public/profile.js
@@ -6,6 +6,17 @@ const readListEl = document.getElementById("read-list");
 const wantListEl = document.getElementById("want-list");
 const readEmptyEl = document.getElementById("read-empty");
 const wantEmptyEl = document.getElementById("want-empty");
+const challengeForm = document.getElementById("challenge-form");
+const joinChallengeForm = document.getElementById("join-challenge-form");
+const challengeNameEl = document.getElementById("challenge-name");
+const challengeDescriptionEl = document.getElementById("challenge-description");
+const challengeCodeEl = document.getElementById("challenge-code");
+const challengeMessageEl = document.getElementById("challenge-message");
+const challengeListEl = document.getElementById("challenge-list");
+const challengeEmptyEl = document.getElementById("challenge-empty");
+const challengeDetailEl = document.getElementById("challenge-detail");
+
+let selectedChallengeId = null;
 
 function createBookCard(book) {
   const card = document.createElement("div");
@@ -39,6 +50,50 @@ function createBookCard(book) {
   return card;
 }
 
+function createChallengeCard(challenge) {
+  const card = document.createElement("div");
+  card.className = "challenge-card";
+
+  const title = document.createElement("h5");
+  title.textContent = challenge.name;
+
+  const meta = document.createElement("p");
+  meta.className = "challenge-card-meta";
+  meta.textContent = `${challenge.book_count} books • ${challenge.member_count} members`;
+
+  const code = document.createElement("p");
+  code.className = "challenge-card-code";
+  code.textContent = `Invite code: ${challenge.invite_code}`;
+
+  const button = document.createElement("button");
+  button.className = "action-btn";
+  button.textContent =
+    Number(challenge.challenge_id) === Number(selectedChallengeId) ? "Viewing" : "View challenge";
+  button.disabled = Number(challenge.challenge_id) === Number(selectedChallengeId);
+  button.addEventListener("click", () => {
+    loadChallengeDetail(challenge.challenge_id);
+  });
+
+  card.appendChild(title);
+  card.appendChild(meta);
+  card.appendChild(code);
+
+  if (challenge.description) {
+    const description = document.createElement("p");
+    description.className = "challenge-card-description";
+    description.textContent = challenge.description;
+    card.appendChild(description);
+  }
+
+  card.appendChild(button);
+  return card;
+}
+
+function setChallengeMessage(text, color = "#2a5db0") {
+  challengeMessageEl.textContent = text;
+  challengeMessageEl.style.color = text ? color : "";
+}
+
 function ensureLoggedIn() {
   if (!uid) {
     window.location.href = "login.html";
@@ -46,6 +101,106 @@ function ensureLoggedIn() {
   }
   userNameEl.textContent = username ? `Hello, ${username}!` : "Hello!";
   return true;
+}
+
+function renderChallengeList(challenges) {
+  challengeListEl.innerHTML = "";
+
+  if (!Array.isArray(challenges) || challenges.length === 0) {
+    challengeEmptyEl.textContent = "You have not created or joined any challenges yet.";
+    return;
+  }
+
+  challengeEmptyEl.textContent = "";
+  challenges.forEach((challenge) => {
+    challengeListEl.appendChild(createChallengeCard(challenge));
+  });
+}
+
+async function fetchChallenges() {
+  const res = await fetch(`/api/challenges/user/${uid}`);
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error || "Unable to load challenges");
+  }
+
+  return data;
+}
+
+async function loadChallengeDetail(challengeId) {
+  selectedChallengeId = challengeId;
+
+  try {
+    const res = await fetch(`/api/challenges/${challengeId}?uid=${encodeURIComponent(uid)}`);
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.error || "Unable to load challenge");
+    }
+
+    const memberItems = data.members.map((member) => `<li>${member.username}</li>`).join("");
+
+    challengeDetailEl.innerHTML = `
+      <div class="challenge-detail-card">
+        <div class="challenge-detail-header">
+          <div>
+            <h4>${data.challenge.name}</h4>
+            <p class="challenge-card-code">Invite code: ${data.challenge.invite_code}</p>
+          </div>
+          <p class="challenge-detail-meta">Created by ${data.challenge.creator_name}</p>
+        </div>
+        ${
+          data.challenge.description
+            ? `<p class="challenge-detail-description">${data.challenge.description}</p>`
+            : ""
+        }
+        <div class="challenge-detail-columns">
+          <section>
+            <h5>Members</h5>
+            <ul class="challenge-member-list">${memberItems}</ul>
+          </section>
+          <section>
+            <h5>Challenge books</h5>
+            <div id="challenge-book-grid" class="challenge-book-grid"></div>
+          </section>
+        </div>
+      </div>
+    `;
+
+    const challengeBookGrid = document.getElementById("challenge-book-grid");
+    if (data.books.length === 0) {
+      challengeBookGrid.innerHTML = '<p class="challenge-empty">No books in this challenge yet.</p>';
+    } else {
+      data.books.forEach((book) => challengeBookGrid.appendChild(createBookCard(book)));
+    }
+
+    renderChallengeList(await fetchChallenges());
+  } catch (error) {
+    challengeDetailEl.innerHTML =
+      '<p class="challenge-empty">Unable to load challenge details right now.</p>';
+  }
+}
+
+async function loadChallenges(preferredChallengeId) {
+  if (!ensureLoggedIn()) return;
+
+  try {
+    const challenges = await fetchChallenges();
+    renderChallengeList(challenges);
+
+    if (!Array.isArray(challenges) || challenges.length === 0) {
+      challengeDetailEl.innerHTML = "";
+      selectedChallengeId = null;
+      return;
+    }
+
+    const challengeId = preferredChallengeId || selectedChallengeId || challenges[0].challenge_id;
+    await loadChallengeDetail(challengeId);
+  } catch (error) {
+    challengeEmptyEl.textContent = "Unable to load challenges right now.";
+    challengeDetailEl.innerHTML = "";
+  }
 }
 
 async function loadLibrary() {
@@ -86,4 +241,72 @@ document.getElementById("logout-btn").addEventListener("click", () => {
   window.location.href = "login.html";
 });
 
+challengeForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  setChallengeMessage("");
+
+  try {
+    const res = await fetch("/api/challenges", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        uid: Number(uid),
+        name: challengeNameEl.value.trim(),
+        description: challengeDescriptionEl.value.trim(),
+      }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      setChallengeMessage(data.error || "Unable to create challenge.", "red");
+      return;
+    }
+
+    setChallengeMessage(
+      `Challenge created. Share invite code ${data.invite_code} with your teammates.`,
+      "green"
+    );
+    challengeForm.reset();
+    await loadChallenges(data.challenge_id);
+  } catch (error) {
+    setChallengeMessage("Unable to create challenge right now.", "red");
+  }
+});
+
+joinChallengeForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  setChallengeMessage("");
+
+  try {
+    const res = await fetch("/api/challenges/join", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        uid: Number(uid),
+        invite_code: challengeCodeEl.value.trim(),
+      }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      setChallengeMessage(data.error || "Unable to join challenge.", "red");
+      return;
+    }
+
+    setChallengeMessage(
+      data.joined
+        ? `Joined "${data.name}".`
+        : `You are already a member of "${data.name}".`,
+      "green"
+    );
+    joinChallengeForm.reset();
+    await loadChallenges(data.challenge_id);
+  } catch (error) {
+    setChallengeMessage("Unable to join challenge right now.", "red");
+  }
+});
+
 loadLibrary();
+loadChallenges();

--- a/public/style.css
+++ b/public/style.css
@@ -269,9 +269,23 @@ h1 {
   margin-top: 30px;
 }
 
+.recommendations-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
 .recommendations-section h3 {
   font-size: 22px;
-  margin-bottom: 15px;
+  margin: 0;
+}
+
+.recommendations-subtitle {
+  margin: 0 0 15px;
+  font-size: 14px;
+  color: #555;
 }
 
 .recommendations-grid {
@@ -327,8 +341,140 @@ h1 {
 .rec-author {
   font-size: 12px;
   color: #777;
-  margin: 0;
+  margin: 0 0 8px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.rec-reason {
+  font-size: 12px;
+  color: #2a5db0;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.rec-rating {
+  font-size: 12px;
+  color: #555;
+  margin: 8px 0 0;
+}
+
+/* ── Reading Challenges ── */
+
+.challenge-section {
+  border-top: 1px solid #e5e5e5;
+  padding-top: 10px;
+}
+
+.challenge-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.challenge-note {
+  margin: 0;
+  color: #666;
+  font-size: 14px;
+}
+
+.challenge-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.challenge-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: #f8f9fc;
+  border: 1px solid #d8deec;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.challenge-form h4 {
+  margin: 0 0 6px;
+}
+
+.challenge-form label {
+  font-size: 14px;
+  color: #555;
+}
+
+.challenge-form input,
+.challenge-form textarea {
+  font: inherit;
+  padding: 10px 12px;
+  border: 1px solid #c2cad7;
+  border-radius: 6px;
+  resize: vertical;
+}
+
+.challenge-message,
+.challenge-empty {
+  margin: 0;
+  font-size: 14px;
+  color: #666;
+}
+
+.challenge-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.challenge-card,
+.challenge-detail-card {
+  background: white;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.challenge-card h5,
+.challenge-detail-card h4,
+.challenge-detail-card h5 {
+  margin: 0 0 8px;
+}
+
+.challenge-card-meta,
+.challenge-card-code,
+.challenge-card-description,
+.challenge-detail-meta,
+.challenge-detail-description {
+  margin: 0 0 10px;
+  font-size: 14px;
+  color: #555;
+}
+
+.challenge-detail {
+  margin-top: 10px;
+}
+
+.challenge-detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.challenge-detail-columns {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr;
+  gap: 24px;
+}
+
+.challenge-member-list {
+  margin: 0;
+  padding-left: 20px;
+  color: #333;
+}
+
+.challenge-book-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
 }

--- a/server.js
+++ b/server.js
@@ -7,6 +7,8 @@ const PORT = 3001;
 const SEARCH_FIELDS = new Set(["title", "author", "genre"]);
 const SEARCH_RESULT_LIMIT = 8;
 const RECOMMENDATION_LIMIT = 5;
+const RECOMMENDATION_POOL_LIMIT = 15;
+const CHALLENGE_CODE_LENGTH = 6;
 
 const pool = mysql.createPool({
   host: "127.0.0.1",
@@ -31,6 +33,127 @@ function sendServerError(res, context, error) {
 
 function getTrimmedQueryParam(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function generateInviteCode() {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  let code = "";
+  for (let i = 0; i < CHALLENGE_CODE_LENGTH; i += 1) {
+    code += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return code;
+}
+
+async function createUniqueInviteCode(conn) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const inviteCode = generateInviteCode();
+    const [rows] = await conn.execute(
+      "SELECT challenge_id FROM reading_challenges WHERE invite_code = ?",
+      [inviteCode]
+    );
+
+    if (rows.length === 0) {
+      return inviteCode;
+    }
+  }
+
+  throw new Error("Unable to generate a unique invite code");
+}
+
+async function ensureDatabaseTables() {
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS reading_challenges (
+      challenge_id INT NOT NULL AUTO_INCREMENT,
+      name VARCHAR(150) NOT NULL,
+      description VARCHAR(255) DEFAULT NULL,
+      invite_code VARCHAR(20) NOT NULL,
+      created_by INT NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (challenge_id),
+      UNIQUE KEY invite_code (invite_code),
+      CONSTRAINT fk_reading_challenges_user
+        FOREIGN KEY (created_by) REFERENCES users(uid) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS challenge_members (
+      challenge_id INT NOT NULL,
+      uid INT NOT NULL,
+      joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (challenge_id, uid),
+      CONSTRAINT fk_challenge_members_challenge
+        FOREIGN KEY (challenge_id) REFERENCES reading_challenges(challenge_id) ON DELETE CASCADE,
+      CONSTRAINT fk_challenge_members_user
+        FOREIGN KEY (uid) REFERENCES users(uid) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+
+  await pool.execute(`
+    CREATE TABLE IF NOT EXISTS challenge_books (
+      challenge_id INT NOT NULL,
+      book_id INT NOT NULL,
+      added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (challenge_id, book_id),
+      CONSTRAINT fk_challenge_books_challenge
+        FOREIGN KEY (challenge_id) REFERENCES reading_challenges(challenge_id) ON DELETE CASCADE,
+      CONSTRAINT fk_challenge_books_book
+        FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  `);
+}
+
+function buildRecommendationReason(matchedGenres, averageRating) {
+  const overlapText =
+    matchedGenres.length === 1
+      ? `Shares the ${matchedGenres[0]} genre with this book`
+      : `Shares genres with this book: ${matchedGenres.join(", ")}`;
+  return overlapText;
+}
+
+function pickRecommendations(candidateRows, limit) {
+  const pool = candidateRows
+    .slice(0, RECOMMENDATION_POOL_LIMIT)
+    .map((row, index) => {
+      const normalizedRating = row.average_rating ? Number(row.average_rating) : 0;
+      return {
+        ...row,
+        randomWeight:
+          row.overlap_count * 100 +
+          normalizedRating * 10 +
+          Math.max(RECOMMENDATION_POOL_LIMIT - index, 1),
+      };
+    });
+
+  const selected = [];
+
+  while (pool.length > 0 && selected.length < limit) {
+    const totalWeight = pool.reduce((sum, candidate) => sum + candidate.randomWeight, 0);
+    let threshold = Math.random() * totalWeight;
+    let chosenIndex = 0;
+
+    for (let i = 0; i < pool.length; i += 1) {
+      threshold -= pool[i].randomWeight;
+      if (threshold <= 0) {
+        chosenIndex = i;
+        break;
+      }
+    }
+
+    const [picked] = pool.splice(chosenIndex, 1);
+    selected.push(picked);
+  }
+
+  return selected.sort((left, right) => {
+    const ratingDiff = (Number(right.average_rating) || 0) - (Number(left.average_rating) || 0);
+    if (right.overlap_count !== left.overlap_count) {
+      return right.overlap_count - left.overlap_count;
+    }
+    if (ratingDiff !== 0) {
+      return ratingDiff;
+    }
+    return left.title.localeCompare(right.title) || left.book_id - right.book_id;
+  });
 }
 
 app.get("/api/search", async (req, res) => {
@@ -346,7 +469,7 @@ app.get("/api/recommendations/:id", async (req, res) => {
     }
 
     const [books] = await pool.execute(
-      `SELECT primary_genre FROM books WHERE book_id = ?`,
+      `SELECT book_id, primary_genre FROM books WHERE book_id = ?`,
       [bookId]
     );
 
@@ -354,19 +477,42 @@ app.get("/api/recommendations/:id", async (req, res) => {
       return res.status(404).json({ error: "Book not found" });
     }
 
-    const genre = books[0].primary_genre;
+    const [genreRows] = await pool.execute(
+      `SELECT DISTINCT g.genre_name
+       FROM genres g
+       JOIN book_genres bg ON g.genre_id = bg.genre_id
+       JOIN books b ON b.hardcover_id = bg.hardcover_id
+       WHERE b.book_id = ?
+       ORDER BY g.genre_name ASC`,
+      [bookId]
+    );
 
-    if (!genre) {
+    const selectedGenres = genreRows.map((row) => row.genre_name);
+    if (selectedGenres.length === 0 && books[0].primary_genre) {
+      selectedGenres.push(books[0].primary_genre);
+    }
+
+    if (selectedGenres.length === 0) {
       return res.json([]);
     }
 
+    const genrePlaceholders = selectedGenres.map(() => "?").join(", ");
     let sql = `
-      SELECT b.book_id, b.title, b.author, b.cover_image_url, b.average_rating
+      SELECT
+        b.book_id,
+        b.title,
+        b.author,
+        b.cover_image_url,
+        b.average_rating,
+        COUNT(DISTINCT g.genre_id) AS overlap_count,
+        GROUP_CONCAT(DISTINCT g.genre_name ORDER BY g.genre_name SEPARATOR '||') AS matched_genres
       FROM books b
-      WHERE b.primary_genre = ?
+      JOIN book_genres bg ON b.hardcover_id = bg.hardcover_id
+      JOIN genres g ON bg.genre_id = g.genre_id
+      WHERE g.genre_name IN (${genrePlaceholders})
         AND b.book_id != ?
     `;
-    const params = [genre, bookId];
+    const params = [...selectedGenres, bookId];
 
     if (uid) {
       sql += `
@@ -385,13 +531,42 @@ app.get("/api/recommendations/:id", async (req, res) => {
     }
 
     sql += `
-      ORDER BY b.average_rating DESC, b.title ASC, b.book_id ASC
-      LIMIT ${RECOMMENDATION_LIMIT}
+      GROUP BY b.book_id, b.title, b.author, b.cover_image_url, b.average_rating
+      ORDER BY overlap_count DESC, b.average_rating DESC, b.title ASC, b.book_id ASC
+      LIMIT ${RECOMMENDATION_POOL_LIMIT}
     `;
 
     const [rows] = await pool.execute(sql, params);
 
-    res.json(rows);
+    const rankedRows = rows.sort((left, right) => {
+      if (right.overlap_count !== left.overlap_count) {
+        return right.overlap_count - left.overlap_count;
+      }
+
+      const ratingDiff = (Number(right.average_rating) || 0) - (Number(left.average_rating) || 0);
+      if (ratingDiff !== 0) {
+        return ratingDiff;
+      }
+
+      return left.title.localeCompare(right.title) || left.book_id - right.book_id;
+    });
+
+    const recommendations = pickRecommendations(rankedRows, RECOMMENDATION_LIMIT).map((row) => {
+      const matchedGenres = row.matched_genres ? row.matched_genres.split("||") : [];
+
+      return {
+        book_id: row.book_id,
+        title: row.title,
+        author: row.author,
+        cover_image_url: row.cover_image_url,
+        average_rating: row.average_rating,
+        matched_genres: matchedGenres,
+        overlap_count: row.overlap_count,
+        reason: buildRecommendationReason(matchedGenres, row.average_rating),
+      };
+    });
+
+    res.json(recommendations);
   } catch (error) {
     sendServerError(res, "Recommendations error", error);
   }
@@ -503,6 +678,240 @@ app.get("/api/user/:uid/ratings", async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running at http://localhost:${PORT}`);
+// ── Create reading challenge from a user's want-to-read list ──
+app.post("/api/challenges", async (req, res) => {
+  try {
+    const uid = parsePositiveInt(req.body.uid);
+    const name = getTrimmedQueryParam(req.body.name);
+    const description = getTrimmedQueryParam(req.body.description).slice(0, 255) || null;
+
+    if (!uid) {
+      return res.status(400).json({ error: "uid is required" });
+    }
+
+    if (!name) {
+      return res.status(400).json({ error: "Challenge name is required" });
+    }
+
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      const [userRows] = await conn.execute("SELECT uid FROM users WHERE uid = ?", [uid]);
+      if (userRows.length === 0) {
+        await conn.rollback();
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      const [wantRows] = await conn.execute(
+        "SELECT book_id FROM want_to_read WHERE uid = ? ORDER BY book_id ASC",
+        [uid]
+      );
+
+      if (wantRows.length === 0) {
+        await conn.rollback();
+        return res.status(400).json({
+          error: "Add at least one book to your Want to Read list before creating a challenge",
+        });
+      }
+
+      const inviteCode = await createUniqueInviteCode(conn);
+      const [result] = await conn.execute(
+        `INSERT INTO reading_challenges (name, description, invite_code, created_by)
+         VALUES (?, ?, ?, ?)`,
+        [name, description, inviteCode, uid]
+      );
+
+      const challengeId = result.insertId;
+
+      await conn.execute(
+        "INSERT INTO challenge_members (challenge_id, uid) VALUES (?, ?)",
+        [challengeId, uid]
+      );
+
+      await conn.execute(
+        `INSERT INTO challenge_books (challenge_id, book_id)
+         SELECT ?, book_id
+         FROM want_to_read
+         WHERE uid = ?`,
+        [challengeId, uid]
+      );
+
+      await conn.commit();
+      res.status(201).json({
+        challenge_id: challengeId,
+        invite_code: inviteCode,
+        name,
+        description,
+        book_count: wantRows.length,
+      });
+    } catch (error) {
+      await conn.rollback();
+      throw error;
+    } finally {
+      conn.release();
+    }
+  } catch (error) {
+    sendServerError(res, "Create challenge error", error);
+  }
 });
+
+// ── Join a reading challenge by invite code ──
+app.post("/api/challenges/join", async (req, res) => {
+  try {
+    const uid = parsePositiveInt(req.body.uid);
+    const inviteCode = getTrimmedQueryParam(req.body.invite_code).toUpperCase();
+
+    if (!uid || !inviteCode) {
+      return res.status(400).json({ error: "uid and invite_code are required" });
+    }
+
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+
+      const [challengeRows] = await conn.execute(
+        `SELECT challenge_id, name
+         FROM reading_challenges
+         WHERE invite_code = ?`,
+        [inviteCode]
+      );
+
+      if (challengeRows.length === 0) {
+        await conn.rollback();
+        return res.status(404).json({ error: "Challenge not found" });
+      }
+
+      const challenge = challengeRows[0];
+      const [result] = await conn.execute(
+        `INSERT IGNORE INTO challenge_members (challenge_id, uid)
+         VALUES (?, ?)`,
+        [challenge.challenge_id, uid]
+      );
+
+      await conn.commit();
+      res.json({
+        challenge_id: challenge.challenge_id,
+        name: challenge.name,
+        joined: result.affectedRows > 0,
+      });
+    } catch (error) {
+      await conn.rollback();
+      throw error;
+    } finally {
+      conn.release();
+    }
+  } catch (error) {
+    sendServerError(res, "Join challenge error", error);
+  }
+});
+
+// ── List challenges for a user ──
+app.get("/api/challenges/user/:uid", async (req, res) => {
+  try {
+    const uid = parsePositiveInt(req.params.uid);
+
+    if (!uid) {
+      return res.status(400).json({ error: "uid must be a positive integer" });
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT
+         c.challenge_id,
+         c.name,
+         c.description,
+         c.invite_code,
+         c.created_at,
+         CASE WHEN c.created_by = ? THEN 1 ELSE 0 END AS is_creator,
+         (SELECT COUNT(*) FROM challenge_members cm WHERE cm.challenge_id = c.challenge_id) AS member_count,
+         (SELECT COUNT(*) FROM challenge_books cb WHERE cb.challenge_id = c.challenge_id) AS book_count
+       FROM reading_challenges c
+       JOIN challenge_members cm ON cm.challenge_id = c.challenge_id
+       WHERE cm.uid = ?
+       ORDER BY c.created_at DESC, c.challenge_id DESC`,
+      [uid, uid]
+    );
+
+    res.json(rows);
+  } catch (error) {
+    sendServerError(res, "List challenges error", error);
+  }
+});
+
+// ── Challenge detail for a member ──
+app.get("/api/challenges/:id", async (req, res) => {
+  try {
+    const challengeId = parsePositiveInt(req.params.id);
+    const uid = parsePositiveInt(req.query.uid);
+
+    if (!challengeId || !uid) {
+      return res.status(400).json({ error: "challenge id and uid are required" });
+    }
+
+    const [membershipRows] = await pool.execute(
+      `SELECT 1
+       FROM challenge_members
+       WHERE challenge_id = ? AND uid = ?`,
+      [challengeId, uid]
+    );
+
+    if (membershipRows.length === 0) {
+      return res.status(403).json({ error: "You must join this challenge before viewing it" });
+    }
+
+    const [challengeRows] = await pool.execute(
+      `SELECT
+         c.challenge_id,
+         c.name,
+         c.description,
+         c.invite_code,
+         c.created_at,
+         u.username AS creator_name
+       FROM reading_challenges c
+       JOIN users u ON c.created_by = u.uid
+       WHERE c.challenge_id = ?`,
+      [challengeId]
+    );
+
+    if (challengeRows.length === 0) {
+      return res.status(404).json({ error: "Challenge not found" });
+    }
+
+    const [memberRows] = await pool.execute(
+      `SELECT u.uid, u.username
+       FROM challenge_members cm
+       JOIN users u ON cm.uid = u.uid
+       WHERE cm.challenge_id = ?
+       ORDER BY u.username ASC`,
+      [challengeId]
+    );
+
+    const [bookRows] = await pool.execute(
+      `SELECT b.book_id, b.title, b.author, b.cover_image_url
+       FROM challenge_books cb
+       JOIN books b ON cb.book_id = b.book_id
+       WHERE cb.challenge_id = ?
+       ORDER BY b.title ASC`,
+      [challengeId]
+    );
+
+    res.json({
+      challenge: challengeRows[0],
+      members: memberRows,
+      books: bookRows,
+    });
+  } catch (error) {
+    sendServerError(res, "Challenge detail error", error);
+  }
+});
+
+ensureDatabaseTables()
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server running at http://localhost:${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error("Database setup error:", error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

This PR adds a new reading challenge feature and improves the recommendation system.

### Reading Challenges
- Added backend support for shared reading challenges
- Added automatic database table setup for:
  - `reading_challenges`
  - `challenge_members`
  - `challenge_books`
- Added endpoints to:
  - create a challenge from a user's current Want to Read list
  - join a challenge by invite code
  - list all challenges for a user
  - view challenge details, members, and books

### Profile Page Updates
- Added a new Reading Challenges section on the profile page
- Users can:
  - create a challenge with a name and description
  - join an existing challenge with an invite code
  - view their joined/created challenges
  - open a challenge detail view showing members and shared books

### Recommendation Improvements
- Updated recommendations to use overlapping genres instead of only the book's primary genre. (previous can only return the top 5 ratings)
- Recommendations now:
  - exclude the selected book
  - exclude saved books for logged-in users
  - rank candidates by genre overlap first, then average rating
  - allow refresh-based variation by sampling from a strong candidate pool
- Added recommendation reasons and a visible refresh button on the book page
- Recommendation cards now show average rating on a separate line

### Documentation
- Updated README with the new recommendation behavior
- Added
